### PR TITLE
Add iomanip header

### DIFF
--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <cstring>
 #include <queue>
+#include <iomanip>
 
 #include "constraints.impl.h"
 #include "fpga_interchange.h"


### PR DESCRIPTION
This change is required to build nextpnr-fpga_interchange as a single-threaded application and does not affect other build options.